### PR TITLE
Compute reprojection errors during conversion to colmap

### DIFF
--- a/glomap/io/colmap_converter.cc
+++ b/glomap/io/colmap_converter.cc
@@ -106,6 +106,8 @@ void ConvertGlomapToColmap(const std::unordered_map<camera_t, Camera>& cameras,
 
     reconstruction.AddImage(std::move(image_colmap));
   }
+
+  reconstruction.UpdatePoint3DErrors();
 }
 
 void ConvertColmapToGlomap(const colmap::Reconstruction& reconstruction,


### PR DESCRIPTION
It is handy to directly compare output of colmap's model_analyzer, but reconstructions that glomap outputs do not have computed reprojection errors.