### PR TITLE
Robustly handle undistortion failures

### DIFF
--- a/glomap/estimators/cost_function.h
+++ b/glomap/estimators/cost_function.h
@@ -14,7 +14,7 @@ namespace glomap {
 // from two positions such that t_ij - scale * (c_j - c_i) is minimized.
 struct BATAPairwiseDirectionError {
   BATAPairwiseDirectionError(const Eigen::Vector3d& translation_obs)
-      : translation_obs_(translation_obs){};
+      : translation_obs_(translation_obs) {}
 
   // The error is given by the position error described above.
   template <typename T>
@@ -22,19 +22,11 @@ struct BATAPairwiseDirectionError {
                   const T* position2,
                   const T* scale,
                   T* residuals) const {
-    Eigen::Matrix<T, 3, 1> translation;
-    translation[0] = position2[0] - position1[0];
-    translation[1] = position2[1] - position1[1];
-    translation[2] = position2[2] - position1[2];
-
-    Eigen::Matrix<T, 3, 1> residual_vec;
-
-    residual_vec = translation_obs_.cast<T>() - scale[0] * translation;
-
-    residuals[0] = residual_vec(0);
-    residuals[1] = residual_vec(1);
-    residuals[2] = residual_vec(2);
-
+    Eigen::Map<Eigen::Matrix<T, 3, 1>> residuals_vec(residuals);
+    residuals_vec =
+        translation_obs_.cast<T>() -
+        scale[0] * (Eigen::Map<const Eigen::Matrix<T, 3, 1>>(position2) -
+                    Eigen::Map<const Eigen::Matrix<T, 3, 1>>(position1));
     return true;
   }
 

--- a/glomap/estimators/global_positioning.cc
+++ b/glomap/estimators/global_positioning.cc
@@ -159,8 +159,7 @@ void GlobalPositioner::AddCameraToCameraConstraints(
       continue;
     }
 
-
-        CHECK_GT(scales_.capacity(), scales_.size())
+    CHECK_GT(scales_.capacity(), scales_.size())
         << "Not enough capacity was reserved for the scales.";
     double& scale = scales_.emplace_back(1);
 

--- a/glomap/estimators/global_positioning.cc
+++ b/glomap/estimators/global_positioning.cc
@@ -290,13 +290,13 @@ void GlobalPositioner::AddTrackToProblem(
                                  loss_function_ptcam_calibrated_.get(),
                                  image.cam_from_world.translation.data(),
                                  tracks[track_id].xyz.data(),
-                                 &(scales_[counter]));
+                                 &scale);
     } else {
       problem_->AddResidualBlock(cost_function,
                                  loss_function_ptcam_uncalibrated_.get(),
                                  image.cam_from_world.translation.data(),
                                  tracks[track_id].xyz.data(),
-                                 &(scales_[counter]));
+                                 &scale);
     }
 
     problem_->SetParameterLowerBound(&scale, 0, 1e-5);

--- a/glomap/estimators/global_positioning.cc
+++ b/glomap/estimators/global_positioning.cc
@@ -142,13 +142,14 @@ void GlobalPositioner::AddCameraToCameraConstraints(
     const image_t image_id1 = image_pair.image_id1;
     const image_t image_id2 = image_pair.image_id2;
     if (images.find(image_id1) == images.end() ||
-        images.find(image_id2) == images.end())
+        images.find(image_id2) == images.end()) {
       continue;
+    }
 
-    track_t counter = scales_.size();
-    scales_.insert(std::make_pair(counter, 1));
+    const track_t counter = scales_.size();
+    scales_[counter] = 1;
 
-    Eigen::Vector3d translation =
+    const Eigen::Vector3d translation =
         -(images[image_id2].cam_from_world.rotation.inverse() *
           image_pair.cam2_from_cam1.translation);
     ceres::CostFunction* cost_function =
@@ -230,7 +231,7 @@ void GlobalPositioner::AddPointToCameraConstraints(
 }
 
 void GlobalPositioner::AddTrackToProblem(
-    const track_t& track_id,
+    track_t track_id,
     std::unordered_map<camera_t, Camera>& cameras,
     std::unordered_map<image_t, Image>& images,
     std::unordered_map<track_t, Track>& tracks) {
@@ -241,34 +242,48 @@ void GlobalPositioner::AddTrackToProblem(
     Image& image = images[observation.first];
     if (!image.is_registered) continue;
 
-    Eigen::Vector3d translation = image.cam_from_world.rotation.inverse() *
-                                  image.features_undist[observation.second];
+    const Eigen::Vector3d& feature_undist =
+        image.features_undist[observation.second];
+    if (feature_undist.array().isNaN().any()) {
+      LOG(WARNING)
+          << "Ignoring feature because it failed to undistort: track_id="
+          << track_id << ", image_id=" << observation.first
+          << ", feature_id=" << observation.second;
+      continue;
+    }
+
+    const Eigen::Vector3d translation =
+        image.cam_from_world.rotation.inverse() *
+        image.features_undist[observation.second];
     ceres::CostFunction* cost_function =
         BATAPairwiseDirectionError::Create(translation);
 
-    track_t counter = scales_.size();
+    const track_t counter = scales_.size();
     if (options_.generate_scales || !tracks[track_id].is_initialized) {
-      scales_.insert(std::make_pair(counter, 1));
+      scales_[counter] = 1;
     } else {
-      Eigen::Vector3d trans_calc =
+      const Eigen::Vector3d trans_calc =
           tracks[track_id].xyz - image.cam_from_world.translation;
-      double scale = translation.dot(trans_calc) / trans_calc.squaredNorm();
-      scales_.insert(std::make_pair(counter, std::max(scale, 1e-5)));
+      const double scale =
+          translation.dot(trans_calc) / trans_calc.squaredNorm();
+      scales_[counter] = std::max(scale, 1e-5);
     }
 
     // For calibrated and uncalibrated cameras, use different loss functions
     // Down weight the uncalibrated cameras
-    (cameras[image.camera_id].has_prior_focal_length)
-        ? problem_->AddResidualBlock(cost_function,
-                                     loss_function_ptcam_calibrated_.get(),
-                                     image.cam_from_world.translation.data(),
-                                     tracks[track_id].xyz.data(),
-                                     &(scales_[counter]))
-        : problem_->AddResidualBlock(cost_function,
-                                     loss_function_ptcam_uncalibrated_.get(),
-                                     image.cam_from_world.translation.data(),
-                                     tracks[track_id].xyz.data(),
-                                     &(scales_[counter]));
+    if (cameras[image.camera_id].has_prior_focal_length) {
+      problem_->AddResidualBlock(cost_function,
+                                 loss_function_ptcam_calibrated_.get(),
+                                 image.cam_from_world.translation.data(),
+                                 tracks[track_id].xyz.data(),
+                                 &(scales_[counter]));
+    } else {
+      problem_->AddResidualBlock(cost_function,
+                                 loss_function_ptcam_uncalibrated_.get(),
+                                 image.cam_from_world.translation.data(),
+                                 tracks[track_id].xyz.data(),
+                                 &(scales_[counter]));
+    }
 
     problem_->SetParameterLowerBound(&(scales_[counter]), 0, 1e-5);
   }

--- a/glomap/estimators/global_positioning.h
+++ b/glomap/estimators/global_positioning.h
@@ -80,7 +80,7 @@ class GlobalPositioner {
       std::unordered_map<track_t, Track>& tracks);
 
   // Add a single track to the problem
-  void AddTrackToProblem(const track_t& track_id,
+  void AddTrackToProblem(track_t track_id,
                          std::unordered_map<camera_t, Camera>& cameras,
                          std::unordered_map<image_t, Image>& images,
                          std::unordered_map<track_t, Track>& tracks);

--- a/glomap/estimators/relpose_estimation.cc
+++ b/glomap/estimators/relpose_estimation.cc
@@ -30,7 +30,7 @@ void EstimateRelativePoses(ViewGraph& view_graph,
         std::min<int64_t>((chunk_id + 1) * inverval, num_image_pairs);
 
 #pragma omp parallel for schedule(dynamic) private( \
-        points2D_1, points2D_2, inliers)
+    points2D_1, points2D_2, inliers)
     for (int64_t pair_idx = start; pair_idx < end; pair_idx++) {
       ImagePair& image_pair = view_graph.image_pairs[valid_pair_ids[pair_idx]];
       const Image& image1 = images[image_pair.image_id1];

--- a/glomap/processors/track_filter.cc
+++ b/glomap/processors/track_filter.cc
@@ -37,7 +37,7 @@ int TrackFilter::FilterTracksByReprojection(
 
       // If the reprojection error is smaller than the threshold, then keep it
       if (reprojection_error < max_reprojection_error) {
-        observation_new.emplace_back(std::make_pair(image_id, feature_id));
+        observation_new.emplace_back(image_id, feature_id);
       }
     }
     if (observation_new.size() != track.observations.size()) {

--- a/glomap/scene/image.h
+++ b/glomap/scene/image.h
@@ -47,11 +47,10 @@ struct Image {
   // Gravity information
   GravityInfo gravity_info;
 
-  // Features
+  // Distorted feature points in pixels.
   std::vector<Eigen::Vector2d> features;
-  std::vector<Eigen::Vector3d>
-      features_undist;  // store the normalized features, can be obtained by
-                        // calling UndistortImages
+  // Normalized feature rays, can be obtained by calling UndistortImages.
+  std::vector<Eigen::Vector3d> features_undist;
 
   // Methods
   inline Eigen::Vector3d Center() const;


### PR DESCRIPTION
In rare cases, keypoint undistortion may fail due to numerical issues. In these cases, the keypoint position may contain NaN values. This leads to NaNs in the global positioning problem and leads to a reconstruction failure.

Fixes issue https://github.com/colmap/glomap/issues/35