### PR TITLE
fix: arg type for std::ceil and typo in glomap::EstimateRelativePoses

### DIFF
--- a/glomap/estimators/relpose_estimation.cc
+++ b/glomap/estimators/relpose_estimation.cc
@@ -20,14 +20,15 @@ void EstimateRelativePoses(ViewGraph& view_graph,
 
   const int64_t num_image_pairs = valid_pair_ids.size();
   const int64_t kNumChunks = 10;
-  const int64_t inverval = std::ceil(num_image_pairs / kNumChunks);
+  const int64_t interval =
+      std::ceil(static_cast<double>(num_image_pairs) / kNumChunks);
   LOG(INFO) << "Estimating relative pose for " << num_image_pairs << " pairs";
   for (int64_t chunk_id = 0; chunk_id < kNumChunks; chunk_id++) {
     std::cout << "\r Estimating relative pose: " << chunk_id * kNumChunks << "%"
               << std::flush;
-    const int64_t start = chunk_id * inverval;
+    const int64_t start = chunk_id * interval;
     const int64_t end =
-        std::min<int64_t>((chunk_id + 1) * inverval, num_image_pairs);
+        std::min<int64_t>((chunk_id + 1) * interval, num_image_pairs);
 
 #pragma omp parallel for schedule(dynamic) private( \
     points2D_1, points2D_2, inliers)


### PR DESCRIPTION
I find this bug when reconstructing 4 images. `std::ceil(num_image_pairs / kNumChunks)` equals to **zero** at here for int64(4/10) equals zero, and the relative pose estimation actually failed here.