### PR TITLE
fix: vector out of bounds in ViewGraph::KeepLargestConnectedComponents

### DIFF
--- a/glomap/controllers/global_mapper.cc
+++ b/glomap/controllers/global_mapper.cc
@@ -63,7 +63,10 @@ bool GlobalMapper::Solve(const colmap::Database& database,
     RelPoseFilter::FilterInlierRatio(
         view_graph, options_.inlier_thresholds.min_inlier_ratio);
 
-    view_graph.KeepLargestConnectedComponents(images);
+    if (view_graph.KeepLargestConnectedComponents(images) == 0) {
+      LOG(ERROR) << "no connected components are found";
+      return false;
+    }
 
     run_timer.PrintSeconds();
   }
@@ -83,7 +86,10 @@ bool GlobalMapper::Solve(const colmap::Database& database,
 
     RelPoseFilter::FilterRotations(
         view_graph, images, options_.inlier_thresholds.max_rotation_error);
-    view_graph.KeepLargestConnectedComponents(images);
+    if (view_graph.KeepLargestConnectedComponents(images) == 0) {
+      LOG(ERROR) << "no connected components are found";
+      return false;
+    }
 
     // The second run is for final estimation
     if (!ra_engine.EstimateRotations(view_graph, images)) {
@@ -92,6 +98,10 @@ bool GlobalMapper::Solve(const colmap::Database& database,
     RelPoseFilter::FilterRotations(
         view_graph, images, options_.inlier_thresholds.max_rotation_error);
     image_t num_img = view_graph.KeepLargestConnectedComponents(images);
+    if (num_img == 0) {
+      LOG(ERROR) << "no connected components are found";
+      return false;
+    }
     LOG(INFO) << num_img << " / " << images.size()
               << " images are within the connected component." << std::endl;
 

--- a/glomap/scene/view_graph.cc
+++ b/glomap/scene/view_graph.cc
@@ -21,6 +21,8 @@ int ViewGraph::KeepLargestConnectedComponents(
     }
   }
 
+  if (max_img == 0) return 0;
+
   std::unordered_set<image_t> largest_component = connected_components[max_idx];
 
   // Set all images to not registered


### PR DESCRIPTION
In the most extreme condition, all image pairs could be invalid and there are no connected_components. This will crash the program with a SIGSEGV signal like:
```
*** SIGSEGV (@0x29) received by PID 301534 (TID 0x7cbe1f456540) from PID 41; stack trace: ***
    @     0x7cbe2355b046 (unknown)
    @     0x7cbe20a42520 (unknown)
    @     0x58497c373f83 std::_Hashtable<>::_M_assign<>()
    @     0x58497c372b17 glomap::ViewGraph::KeepLargestConnectedComponents()
    @     0x58497c28cbfa glomap::GlobalMapper::Solve()
    @     0x58497c2882ac glomap::RunMapper()
    @     0x58497c28688f main
    @     0x7cbe20a29d90 (unknown)
    @     0x7cbe20a29e40 __libc_start_main
    @     0x58497c2864b5 _start
```

I think some conditional statements should be added here to avoid crash. And the `GlobalMapper::Solve` function should return when no connected components are found.

After adding this statement, the program doesn't crash and the log looks like:
```
-------------------------------------
Running rotation averaging ...
-------------------------------------
I0910 16:29:13.657310 423892 relpose_filter.cc:31] Filtered 4 relative rotation with angle > 10 degrees
E0910 16:29:13.657315 423892 global_mapper.cc:90] no connected components are found
I0910 16:29:13.657357 423892 global_mapper.cc:86] Reconstruction done in 0.299914 seconds
I0910 16:29:13.657366 423892 colmap_io.cc:27] Extracting colors ...
........
I0910 16:29:13.657447 423892 global_mapper.cc:91] Export to COLMAP reconstruction done
```