### PR TITLE
Adding GCC flags to ignore warnings from Eigen

### DIFF
--- a/glomap/CMakeLists.txt
+++ b/glomap/CMakeLists.txt
@@ -94,6 +94,9 @@ else()
         -Werror
         -Wno-sign-compare
         -Wno-unused-variable
+        -Wno-maybe-uninitialized
+        -Wno-array-bounds
+        -Wno-stringop-overflow
     )
 endif()
 


### PR DESCRIPTION
I've been getting multiple Eigen warnings in GCC 13, which become errors [because of the `-Werror` flag](https://github.com/colmap/glomap/blob/d41b747407b6c5ce564e3936d0f2f2ea52f89dae/glomap/CMakeLists.txt#L94) used for compilation on Linux. The same error has been reported on https://github.com/colmap/glomap/issues/156.

The first warning is `-Werror=maybe-uninitialized`:
```
.../Eigen/src/Core/PlainObjectBase.h:512:17: error: '*(Eigen::DenseCoeffsBase<Eigen::Matrix<double, 3, 1, 0, 3, 1>, 1>::Scalar*)((char*)&svd + offsetof(Eigen::JacobiSVD<Eigen::Matrix<double, 3, 3, 0, 3, 3>, 2>,Eigen::JacobiSVD<Eigen::Matrix<double, 3, 3, 0, 3, 3>, 2>::<unnamed>.Eigen::SVDBase<Eigen::JacobiSVD<Eigen::Matrix<double, 3, 3, 0, 3, 3>, 2> >::m_singularValues.Eigen::Matrix<double, 3, 1, 0, 3, 1>::<unnamed>.Eigen::PlainObjectBase<Eigen::Matrix<double, 3, 1, 0, 3, 1> >::<unnamed>.Eigen::MatrixBase<Eigen::Matrix<double, 3, 1, 0, 3, 1> >::<unnamed>.Eigen::DenseBase<Eigen::Matrix<double, 3, 1, 0, 3, 1> >::<unnamed>.Eigen::DenseCoeffsBase<Eigen::Matrix<double, 3, 1, 0, 3, 1>, 3>::<unnamed>.Eigen::DenseCoeffsBase<Eigen::Matrix<double, 3, 1, 0, 3, 1>, 1>::<unnamed>.Eigen::DenseCoeffsBase<Eigen::Matrix<double, 3, 1, 0, 3, 1>, 0>::<unnamed>))' may be used uninitialized [-Werror=maybe-uninitialized]
  512 |       : Base(), m_storage(other.m_storage) { }
      |                 ^~~~~~~~~~~~~~~~~~~~~~~~~~
```
I noticed that this one is also addressed in COLMAP [here](https://github.com/colmap/colmap/blob/5618112d6117dba0b9b1cc409b11cff8479a9ca1/CMakeLists.txt#L162).


The second warning is `-Werror=array-bounds`:
```
.../lib/gcc/x86_64-pc-linux-gnu/13.2.0/include/avxintrin.h:875:19: error: array subscript '__m256d[0]' is partly outside array bounds of 'Eigen::Matrix<double, -1, -1, 0, 1, 1> [1]' [-Werror=array-bounds=]
  875 |   *(__m256d *)__P = __A;
      |   ~~~~~~~~~~~~~~~~^~~~~
```
This one is a false positive that has been happening since GCC 12 and which the Eigen team is aware of (https://gitlab.com/libeigen/eigen/-/issues/2506). This bug has already been reported to GCC [here](https://gcc.gnu.org/bugzilla/show_bug.cgi?id=106247).

The third warning is `-Werror=stringop-overflow`:
```
inlined from 'void Eigen::internal::apply_block_householder_on_the_left(MatrixType&, const VectorsType&, const CoeffsType&, bool) [with MatrixType = Eigen::Block<Eigen::Matrix<double, 3, 1>, -1, -1, false>; VectorsType = Eigen::Block<Eigen::Matrix<double, 3, 1>, -1, -1, false>; CoeffsType = Eigen::Block<Eigen::Matrix<double, 1, 1, 0, 1, 1>, -1, 1, false>]' at /apps/all/Eigen/3.4.0-GCCcore-13.2.0/include/Eigen/src/Householder/BlockHouseholder.h:101:19:
.../lib/gcc/x86_64-pc-linux-gnu/13.2.0/include/avxintrin.h:875:19: error: 'void* __builtin_memcpy(void*, const void*, long unsigned int)' writing 32 or more bytes into a region of size 24 overflows the destination [-Werror=stringop-overflow=]
  875 |   *(__m256d *)__P = __A;
      |   ~~~~~~~~~~~~~~~~^~~~~
```
I haven't found it reported on the Eigen repo, but maybe this is also a false positive (?).

My proposal to solve these errors is to add the flags `-Wno-maybe-uninitialized`, `-Wno-array-bounds`, and `-Wno-stringop-overflow` to ignore these warnings. Although another alternative would be to remove the `-Werror` which also worked for me.