### PR TITLE
Use CMAKE_CURRENT_SOURCE_DIR in FindDependencies.cmake

### DIFF
--- a/cmake/FindDependencies.cmake
+++ b/cmake/FindDependencies.cmake
@@ -1,4 +1,4 @@
-set(CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake")
+set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 
 find_package(Eigen3 3.4 REQUIRED)
 find_package(SuiteSparse COMPONENTS CHOLMOD REQUIRED)


### PR DESCRIPTION
- `CMAKE_SOURCE_DIR` refers to the root of the project, while `CMAKE_CURRENT_SOURCE_DIR` refers to the directory from which `FindDependencies.cmake` was included (the `glomap` dir).
- Using `CMAKE_SOURCE_DIR` will break when glomap is built as part of a larger CMake project. `CMAKE_CURRENT_SOURCE_DIR` behaves correctly in this context.