### PR TITLE
Skip `FetchContent` if relevant targets already exist

### DIFF
--- a/cmake/FindDependencies.cmake
+++ b/cmake/FindDependencies.cmake
@@ -21,30 +21,39 @@ if(TESTS_ENABLED)
 endif()
 
 include(FetchContent)
-FetchContent_Declare(PoseLib
-    GIT_REPOSITORY    https://github.com/PoseLib/PoseLib.git
-    GIT_TAG           0439b2d361125915b8821043fca9376e6cc575b9
-    EXCLUDE_FROM_ALL
-    SYSTEM
-)
-message(STATUS "Configuring PoseLib...")
-if (FETCH_POSELIB) 
-    FetchContent_MakeAvailable(PoseLib)
-else()
-    find_package(PoseLib REQUIRED)
-endif()
-message(STATUS "Configuring PoseLib... done")
 
-FetchContent_Declare(COLMAP
-    GIT_REPOSITORY    https://github.com/colmap/colmap.git
-    GIT_TAG           78f1eefacae542d753c2e4f6a26771a0d976227d
-    EXCLUDE_FROM_ALL
-)
-message(STATUS "Configuring COLMAP...")
-set(UNINSTALL_ENABLED OFF CACHE INTERNAL "")
-if (FETCH_COLMAP) 
-    FetchContent_MakeAvailable(COLMAP)
+if (NOT TARGET PoseLib AND NOT TARGET PoseLib::PoseLib)
+    FetchContent_Declare(PoseLib
+        GIT_REPOSITORY    https://github.com/PoseLib/PoseLib.git
+        GIT_TAG           0439b2d361125915b8821043fca9376e6cc575b9
+        EXCLUDE_FROM_ALL
+        SYSTEM
+    )
+    message(STATUS "Configuring PoseLib...")
+    if (FETCH_POSELIB)
+        FetchContent_MakeAvailable(PoseLib)
+    else()
+        find_package(PoseLib REQUIRED)
+    endif()
+    message(STATUS "Configuring PoseLib... done")
 else()
-    find_package(COLMAP REQUIRED)
+    message(STATUS "PoseLib target already exists.")
 endif()
-message(STATUS "Configuring COLMAP... done")
+
+if (NOT TARGET colmap AND NOT TARGET colmap::colmap)
+    FetchContent_Declare(COLMAP
+        GIT_REPOSITORY    https://github.com/colmap/colmap.git
+        GIT_TAG           78f1eefacae542d753c2e4f6a26771a0d976227d
+        EXCLUDE_FROM_ALL
+    )
+    message(STATUS "Configuring COLMAP...")
+    set(UNINSTALL_ENABLED OFF CACHE INTERNAL "")
+    if (FETCH_COLMAP)
+        FetchContent_MakeAvailable(COLMAP)
+    else()
+        find_package(COLMAP REQUIRED)
+    endif()
+    message(STATUS "Configuring COLMAP... done")
+else()
+    message(STATUS "COLMAP target already exists.")
+endif()


### PR DESCRIPTION
- This change alters the behavior of `FindDependencies.cmake` such that the `PoseLib` and `colmap` repos are not fetched if those targets already exist.
- This makes it easier to build glomap in a larger project where `PoseLib` and `colmap` are already CMake sub-projects.