### PR TITLE
Fix out-of-bounds indexation in BundleAdjuster::ParameterizeVariables

### DIFF
--- a/glomap/estimators/bundle_adjustment.cc
+++ b/glomap/estimators/bundle_adjustment.cc
@@ -208,11 +208,13 @@ void BundleAdjuster::ParameterizeVariables(
     }
   }
 
-  // Set the first camera to be fixed to remove the gauge ambiguity.
-  problem_->SetParameterBlockConstant(
-      images[center].cam_from_world.rotation.coeffs().data());
-  problem_->SetParameterBlockConstant(
-      images[center].cam_from_world.translation.data());
+  if (counter > 0) {
+    // Set the first camera to be fixed to remove the gauge ambiguity.
+    problem_->SetParameterBlockConstant(
+        images[center].cam_from_world.rotation.coeffs().data());
+    problem_->SetParameterBlockConstant(
+        images[center].cam_from_world.translation.data());
+  }
 
   // Parameterize the camera parameters, or set them to be constant if desired
   if (options_.optimize_intrinsics && !options_.optimize_principal_point) {


### PR DESCRIPTION
I was sometimes getting this runtime error during BA:
```
F0000 00:00:1741303308.606699   76081 problem_impl.cc:478] Parameter block not found: 0x1db97c0. You must add the parameter block to the problem before it can be set constant.
*** Check failure stack trace: ***
*** Aborted at 1741303308 (unix time) try "date -d @1741303308" if you are using GNU date ***
PC: @     0x14aa0fa6552f __GI_raise
*** SIGABRT (@0x282300012931) received by PID 76081 (TID 0x14aa0aee9d00) from PID 76081; stack trace: ***
    @     0x14aa10661e87 __pthread_once_slow
    @     0x14aa182d58df google::(anonymous namespace)::FailureSignalHandler(int, siginfo_t*, void*)
    @     0x14aa10664d10 (/usr/lib64/libpthread-2.28.so+0x12d0f)
    @     0x14aa0fa6552f __GI_raise
    @     0x14aa0fa38e65 __GI_abort
    @          0x12689c2 absl::lts_20240116::log_internal::LogMessage::FailWithoutStackTrace()
    @          0x1268ce5 absl::lts_20240116::log_internal::LogMessage::Die()
    @          0x1269039 absl::lts_20240116::log_internal::LogMessageFatal::~LogMessageFatal()
    @           0x468697 ceres::internal::ProblemImpl::SetParameterBlockConstant(double const*) [clone .cold]
    @           0x4d6d5e glomap::BundleAdjuster::ParameterizeVariables(std::unordered_map<unsigned int, glomap::Camera, std::hash<unsigned int>, std::equal_to<unsigned int>, std::allocator<std::pair<unsigned int const, glomap::Camera> > >&, std::unordered_map<unsigned int, glomap:

    @           0x4d78dd glomap::BundleAdjuster::Solve(glomap::ViewGraph const&, std::unordered_map<unsigned int, glomap::Camera, std::hash<unsigned int>, std::equal_to<unsigned int>, std::allocator<std::pair<unsigned int const, glomap::Camera> > >&, std::unordered_map<unsigned in

    @           0x4bc786 glomap::GlobalMapper::Solve(colmap::Database const&, glomap::ViewGraph&, std::unordered_map<unsigned int, glomap::Camera, std::hash<unsigned int>, std::equal_to<unsigned int>, std::allocator<std::pair<unsigned int const, glomap::Camera> > >&, std::unordere

    @           0x49b0d5 main
    @     0x14aa0fa517e5 __libc_start_main
    @           0x49dd2e _start
Aborted (core dumped)
```

The crash exhibited a stochastic behavior across multiple executions with the same input data. It was happening only during the BA that is run after the retriangulation stage (not the first BA).

I noticed that this error occurs because `image_t center;` is default initialized (to some garbage value) and its value is set to `image_id` only if the condition `if (counter == 0)` is met. However, it might be the case where its value is never set (because that condition isn't met) and we end up indexing `images` with a very high value (`14227666` in some experiments I did). This of course causes an out-of-bunds indexation that triggers the error from Ceres.

I just propose to check if `counter` isn't 0 to know if the value of `center` was set before the call to `SetParameterBlockConstant`.