### PR TITLE
Comaptibility with `dev` branch of PoseLib

### DIFF
--- a/glomap/controllers/option_manager.cc
+++ b/glomap/controllers/option_manager.cc
@@ -151,7 +151,7 @@ void OptionManager::AddRelativePoseEstimationOptions() {
   added_relative_pose_options_ = true;
   AddAndRegisterDefaultOption(
       "RelPoseEstimation.max_epipolar_error",
-      &mapper->opt_relpose.ransac_options.max_epipolar_error);
+      &mapper->opt_relpose.relpose_options.max_error);
 }
 
 void OptionManager::AddRotationEstimatorOptions() {

--- a/glomap/estimators/relpose_estimation.cc
+++ b/glomap/estimators/relpose_estimation.cc
@@ -98,13 +98,13 @@ void EstimateRelativePoses(ViewGraph& view_graph,
         }
         inliers.clear();
         poselib::CameraPose pose_rel_calc;
+
         try {
           poselib::estimate_relative_pose(points2D_1,
                                           points2D_2,
                                           camera_poselib1,
                                           camera_poselib2,
-                                          options.ransac_options,
-                                          options.bundle_options,
+                                          options.relpose_options,
                                           &pose_rel_calc,
                                           &inliers);
         } catch (const std::exception& e) {

--- a/glomap/estimators/relpose_estimation.cc
+++ b/glomap/estimators/relpose_estimation.cc
@@ -54,12 +54,14 @@ void EstimateRelativePoses(ViewGraph& view_graph,
         // Collect the original 2D points
         points2D_1.clear();
         points2D_2.clear();
-        for (size_t idx = 0; idx < matches.rows(); idx++) {
-          points2D_1.push_back(image1.features[matches(idx, 0)]);
-          points2D_2.push_back(image2.features[matches(idx, 1)]);
-        }
-        // If the camera model is not supported by poselib
-        if (!valid_camera_model) {
+
+        if (valid_camera_model) {
+          for (size_t idx = 0; idx < matches.rows(); idx++) {
+            points2D_1.push_back(image1.features[matches(idx, 0)]);
+            points2D_2.push_back(image2.features[matches(idx, 1)]);
+          }
+        } else {
+          // If the camera model is not supported by poselib
           // Undistort points
           // Note that here, we still rescale by the focal length (to avoid
           // change the RANSAC threshold)
@@ -70,8 +72,15 @@ void EstimateRelativePoses(ViewGraph& view_graph,
           K2_new(0, 0) = camera2.FocalLengthX();
           K2_new(1, 1) = camera2.FocalLengthY();
           for (size_t idx = 0; idx < matches.rows(); idx++) {
-            points2D_1[idx] = K1_new * camera1.CamFromImg(points2D_1[idx]);
-            points2D_2[idx] = K2_new * camera2.CamFromImg(points2D_2[idx]);
+            std::optional<Eigen::Vector2d> p1 = 
+                camera1.CamFromImg(image1.features[matches(idx, 0)]);
+            std::optional<Eigen::Vector2d> p2 = 
+                camera1.CamFromImg(image2.features[matches(idx, 1)]);
+
+            if (!p1 || !p2) continue;
+
+            points2D_1.push_back(p1.value());
+            points2D_2.push_back(p2.value());
           }
 
           // Reset the camera to be the pinhole camera with original focal

--- a/glomap/estimators/relpose_estimation.h
+++ b/glomap/estimators/relpose_estimation.h
@@ -8,10 +8,11 @@ namespace glomap {
 
 struct RelativePoseEstimationOptions {
   // Options for poselib solver
-  poselib::RansacOptions ransac_options;
-  poselib::BundleOptions bundle_options;
+  poselib::RelativePoseOptions relpose_options;
 
-  RelativePoseEstimationOptions() { ransac_options.max_iterations = 50000; }
+  RelativePoseEstimationOptions() { 
+    relpose_options.ransac.max_iterations = 50000; 
+  }
 };
 
 void EstimateRelativePoses(ViewGraph& view_graph,

--- a/glomap/processors/image_undistorter.cc
+++ b/glomap/processors/image_undistorter.cc
@@ -31,8 +31,12 @@ void UndistortImages(std::unordered_map<camera_t, Camera>& cameras,
       image.features_undist.clear();
       image.features_undist.reserve(num_points);
       for (int i = 0; i < num_points; i++) {
-        image.features_undist.emplace_back(
-            camera.CamFromImg(image.features[i]).homogeneous().normalized());
+        std::optional<Eigen::Vector2d> feat_undist = 
+            camera.CamFromImg(image.features[i]);
+            
+        if (feat_undist) image.features_undist.emplace_back(
+          feat_undist.value().homogeneous().normalized()
+        );
       }
     });
   }

--- a/glomap/scene/camera.h
+++ b/glomap/scene/camera.h
@@ -5,7 +5,7 @@
 #include <colmap/scene/camera.h>
 #include <colmap/sensor/models.h>
 
-#include <PoseLib/misc/colmap_models.h>
+#include <PoseLib/misc/camera_models.h>
 
 namespace glomap {
 


### PR DESCRIPTION
This is a follow-up to the previous pull-request (#185). 
Tested with [this commit](https://github.com/PoseLib/PoseLib/commit/4e5e59293c4ed4219a328e046134989541e1f003).

There's no comprehensive benchmark, unfortunately. But, I've ran it on a scene of 3648 images and it was able to register 3453 of them. While the version without it was registering only 9, with the same config.

I'm not sure why this is, but since dev PoseLib has more camera models, it may have to deal with fallbacks when a used camera model is not defined in PoseLib.