### PR TITLE
Expose optimizer `function_tolerance` arguments for global positioning and bundle adjustment

### DIFF
--- a/glomap/controllers/option_manager.cc
+++ b/glomap/controllers/option_manager.cc
@@ -197,6 +197,9 @@ void OptionManager::AddGlobalPositionerOptions() {
   AddAndRegisterDefaultOption(
       "GlobalPositioning.max_num_iterations",
       &mapper->opt_gp.solver_options.max_num_iterations);
+  AddAndRegisterDefaultOption(
+      "GlobalPositioning.function_tolerance",
+      &mapper->opt_gp.solver_options.function_tolerance);
 
   // TODO: move the constrain type selection here
 }
@@ -224,6 +227,9 @@ void OptionManager::AddBundleAdjusterOptions() {
   AddAndRegisterDefaultOption(
       "BundleAdjustment.max_num_iterations",
       &mapper->opt_ba.solver_options.max_num_iterations);
+  AddAndRegisterDefaultOption(
+      "BundleAdjustment.function_tolerance",
+      &mapper->opt_ba.solver_options.function_tolerance);
 }
 void OptionManager::AddTriangulatorOptions() {
   if (added_triangulation_options_) {


### PR DESCRIPTION
- This change adds the Ceres `function_tolerance` (the relative loss function decrease below which the optimization terminates) as command line arguments. The argument is added for the global positioning and bundle adjustment stages.