### PR TITLE
ParameterizeVariables returns false when no poses are present in the optimization

### DIFF
--- a/glomap/estimators/bundle_adjustment.h
+++ b/glomap/estimators/bundle_adjustment.h
@@ -66,7 +66,7 @@ class BundleAdjuster {
       std::unordered_map<track_t, Track>& tracks);
 
   // Parameterize the variables, set some variables to be constant if desired
-  void ParameterizeVariables(std::unordered_map<camera_t, Camera>& cameras,
+  bool ParameterizeVariables(std::unordered_map<camera_t, Camera>& cameras,
                              std::unordered_map<image_t, Image>& images,
                              std::unordered_map<track_t, Track>& tracks);
 


### PR DESCRIPTION
This change addresses an edge case that produces a confusing exception:

- When previous steps of the problem produce poor results (global positioning + track selection), no images will be added to the optimization. In other words, `AddPointToCameraConstraints` adds no variables for the cameras.
- If this occurs, then the variable `center` is never assigned in the loop of `ParameterizeVariables`. As a result, `SetParameterBlockConstant` is passed an address that Ceres is unfamiliar with, causing an exception to occur.

This change explicitly checks for the case where no valid image variables were found, and returns false from `ParameterizeVariables`. An error message is printed, rather than throwing an exception inside ceres.