### PR TITLE
Don't need to do `enable_language(CUDA)`

### DIFF
--- a/cmake/FindDependencies.cmake
+++ b/cmake/FindDependencies.cmake
@@ -71,44 +71,11 @@ message(STATUS "Configuring COLMAP... done")
 
 set(CUDA_MIN_VERSION "7.0")
 if(CUDA_ENABLED)
-    if(CMAKE_VERSION VERSION_LESS 3.17)
-        find_package(CUDA QUIET)
-        if(CUDA_FOUND)
-            message(STATUS "Found CUDA version ${CUDA_VERSION} installed in "
-                    "${CUDA_TOOLKIT_ROOT_DIR} via legacy CMake (<3.17) module. "
-                    "Using the legacy CMake module means that any installation of "
-                    "COLMAP will require that the CUDA libraries are "
-                    "available under LD_LIBRARY_PATH.")
-            message(STATUS "Found CUDA ")
-            message(STATUS "  Includes : ${CUDA_INCLUDE_DIRS}")
-            message(STATUS "  Libraries : ${CUDA_LIBRARIES}")
-
-            enable_language(CUDA)
-
-            macro(declare_imported_cuda_target module)
-                add_library(CUDA::${module} INTERFACE IMPORTED)
-                target_include_directories(
-                    CUDA::${module} INTERFACE ${CUDA_INCLUDE_DIRS})
-                target_link_libraries(
-                    CUDA::${module} INTERFACE ${CUDA_${module}_LIBRARY} ${ARGN})
-            endmacro()
-
-            declare_imported_cuda_target(cudart ${CUDA_LIBRARIES})
-            declare_imported_cuda_target(curand ${CUDA_LIBRARIES})
-
-            set(CUDAToolkit_VERSION "${CUDA_VERSION_STRING}")
-            set(CUDAToolkit_BIN_DIR "${CUDA_TOOLKIT_ROOT_DIR}/bin")
-        else()
-            message(STATUS "CUDA not found")
-        endif()
+    find_package(CUDAToolkit QUIET)
+    if(CUDAToolkit_FOUND)
+        set(CUDA_FOUND ON)
     else()
-        find_package(CUDAToolkit QUIET)
-        if(CUDAToolkit_FOUND)
-            set(CUDA_FOUND ON)
-            enable_language(CUDA)
-        else()
-            message(STATUS "CUDA not found")
-        endif()
+        message(STATUS "CUDA not found")
     endif()
 endif()
 


### PR DESCRIPTION
The project currently does not build any .cu or .cuh files, so the CUDA language support is not really being used. Dropping it makes the project a bit easier to package by not requiring a working NVCC to be available.
The PR is related to https://github.com/valgur/conan-center-index/issues/22 and https://github.com/valgur/conan-center-index/blob/cuda/recipes/glomap/all/conanfile.py.

I also dropped the `if(CMAKE_VERSION VERSION_LESS 3.17)` branch with `find_package(CUDA)` since it will never be taken with `cmake_minimum_required(VERSION 3.28)` being set anyway.