### PR TITLE
fix the id error in retriangulation

### DIFF
--- a/glomap/io/colmap_converter.cc
+++ b/glomap/io/colmap_converter.cc
@@ -309,7 +309,7 @@ void ConvertDatabaseToGlomap(const colmap::Database& database,
   for (const auto& [camera_id, camera] : cameras) {
     if (cameras_id_to_rig_id.find(camera_id) == cameras_id_to_rig_id.end()) {
       Rig rig;
-      if (max_rig_id != 0)
+      if (max_rig_id > 0)
         rig.SetRigId(++max_rig_id);
       else
         rig.SetRigId(camera_id);


### PR DESCRIPTION
A heuristic fix for the id mismatch for the old colmap database. Previously, frame_id / rig_id are randomly assigned when they do not exist in database, now set it to be consistent with the image_id / camera_id. 